### PR TITLE
Make tests a configuration parameter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,7 @@ src_libbitcoin_protocol_la_LIBADD = \
 #
 # tests
 #
+if ENABLE_TESTS
 TESTS = test/libbitcoin_protocol_test
 
 check_PROGRAMS = test/libbitcoin_protocol_test
@@ -66,3 +67,4 @@ test_libbitcoin_protocol_test_LDADD = \
     ${bitcoin_LIBS} \
     ${protobuf_LIBS} \
     ${czmqpp_LIBS}
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -16,13 +16,25 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 # The current versions produce incorrect error message text.
 AX_BOOST_BASE([1.50],,
     [AC_MSG_ERROR([Boost 1.50 or later is required but was not found.])])
-AX_BOOST_UNIT_TEST_FRAMEWORK
 
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES([bitcoin], [libbitcoin >= 2.4.0])
 PKG_CHECK_MODULES([protobuf], [protobuf >= 2.6.0])
 PKG_CHECK_MODULES([czmqpp], [libczmq++ >= 0.4.1])
+
+# build tests
+AC_ARG_WITH([tests], [AS_HELP_STRING([--with-tests],
+    [require build with tests. Requires pkg-config [default=no]])],
+    [enable_tests_ext=$withval],
+    [enable_tests_ext=no])
+
+# conditionally require test dependencies
+if test "x$enable_tests_ext" != "xno"; then
+    AX_BOOST_UNIT_TEST_FRAMEWORK
+fi
+
+AM_CONDITIONAL(ENABLE_TESTS, test "x$enable_tests_ext" != "xno")
 
 # Do not add contextual build parameters in configuration.
 # http://stackoverflow.com/a/4680578

--- a/install-libbitcoin-protocol.sh
+++ b/install-libbitcoin-protocol.sh
@@ -24,6 +24,10 @@ BUILD_ACCOUNT="libbitcoin"
 BUILD_REPO="libbitcoin-protocol"
 BUILD_BRANCH="master"
 
+# enable testing
+TEST_OPTIONS=\
+"--with-tests=yes"
+
 # https://github.com/bitcoin/secp256k1
 SECP256K1_OPTIONS=\
 "--with-bignum=gmp "\
@@ -175,7 +179,7 @@ build_library()
     build_from_github libbitcoin protobuf 2.6.0 "$SEQUENTIAL" "$@"
 
     # The primary build is not downloaded if we are running in Travis.
-    build_primary "$PARALLEL" "$@"
+    build_primary "$PARALLEL" "$@" $TEST_OPTIONS
     
     # If the build succeeded clean up the build directory.
     delete_build_directory


### PR DESCRIPTION
Enable tests via --with-tests configuration parameter, allowing test-only dependencies to be ignored for the purposes of installation.
