### PR TITLE
Socks proxy check correction

### DIFF
--- a/src/zmq/socket.cpp
+++ b/src/zmq/socket.cpp
@@ -207,7 +207,7 @@ bool socket::set_certificate(const certificate& certificate)
 // This must be called on the socket thread.
 bool socket::set_socks_proxy(const config::authority& socks_proxy)
 {
-    return socks_proxy && set(ZMQ_SOCKS_PROXY, socks_proxy.to_string());
+    return socks_proxy ? set(ZMQ_SOCKS_PROXY, socks_proxy.to_string()) : true;
 }
 
 code socket::send(message& packet)

--- a/src/zmq/socket.cpp
+++ b/src/zmq/socket.cpp
@@ -207,7 +207,7 @@ bool socket::set_certificate(const certificate& certificate)
 // This must be called on the socket thread.
 bool socket::set_socks_proxy(const config::authority& socks_proxy)
 {
-    return socks_proxy ? set(ZMQ_SOCKS_PROXY, socks_proxy.to_string()) : true;
+    return !socks_proxy || set(ZMQ_SOCKS_PROXY, socks_proxy.to_string());
 }
 
 code socket::send(message& packet)


### PR DESCRIPTION
if the socks_proxy port is 0, then we return true since we want to connect anyway. if it is not 0, then we set the socks_proxy as intended.