### PR TITLE
Remove critical sections from socket/poller, simplify tests.

### DIFF
--- a/include/bitcoin/protocol/zmq/identifiers.hpp
+++ b/include/bitcoin/protocol/zmq/identifiers.hpp
@@ -30,6 +30,7 @@ namespace zmq {
 /// A locally unique idenfitier for this socket.
 typedef intptr_t identifier;
 
+/// This class is not thread safe.
 /// An indicator for a set of socket idenfitiers.
 class BCP_API identifiers
 {

--- a/include/bitcoin/protocol/zmq/poller.hpp
+++ b/include/bitcoin/protocol/zmq/poller.hpp
@@ -32,7 +32,8 @@ namespace libbitcoin {
 namespace protocol {
 namespace zmq {
 
-/// This class is thread safe except as noted.
+/// This class is not thread safe.
+/// All calls must be made on the socket(s) thread.
 class BCP_API poller
   : public enable_shared_from_base<poller>, noncopyable
 {
@@ -55,22 +56,19 @@ public:
     /// Remove all sockets from the poller.
     void clear();
 
-    /// This must be called on the socket thread.
     /// Wait one second for any socket to receive.
     identifiers wait();
 
-    /// This must be called on the socket thread.
     /// Wait specified time for any socket to receive, -1 is forever.
     identifiers wait(int32_t timeout_milliseconds);
 
 private:
     typedef std::vector<zmq_pollitem> pollers;
 
-    // These values are protected by mutex.
+    // These values are unprotected.
     bool expired_;
     bool terminated_;
     pollers pollers_;
-    mutable shared_mutex mutex_;
 };
 
 } // namespace zmq

--- a/include/bitcoin/protocol/zmq/socket.hpp
+++ b/include/bitcoin/protocol/zmq/socket.hpp
@@ -34,7 +34,8 @@ namespace zmq {
 class message;
 class authenticator;
 
-/// This class is thread safe except as noted.
+/// This class is not thread safe.
+/// All calls must be made on the socket thread.
 /// Because the socket is only set on construct, sockets are not restartable.
 class BCP_API socket
   : public enable_shared_from_base<socket>, noncopyable
@@ -67,10 +68,8 @@ public:
     socket(context& context, role socket_role);
 
     /// Close the socket.
-    /// The object must be destroyed on the socket thread if not stopped.
     virtual ~socket();
 
-    /// This must be called on the socket thread.
     /// Close the socket (optional, must close or destroy before context stop).
     virtual bool stop();
 
@@ -83,35 +82,27 @@ public:
     /// An opaue locally unique idenfier, valid after stop.
     identifier id() const;
 
-    /// This must be called on the socket thread.
     /// Bind the socket to the specified local address.
     code bind(const config::endpoint& address);
 
-    /// This must be called on the socket thread.
     /// Connect the socket to the specified remote address.
     code connect(const config::endpoint& address);
 
-    /// This must be called on the socket thread.
     /// Sets the domain for ZAP (ZMQ RFC 27) authentication.
     bool set_authentication_domain(const std::string& domain);
 
-    /// This must be called on the socket thread.
     /// Configure the socket as a curve server (also set the secrety key).
     bool set_curve_server();
 
-    /// This must be called on the socket thread.
     /// Configure the socket as client to the curve server.
     bool set_curve_client(const config::sodium& server_public_key);
 
-    /// This must be called on the socket thread.
     /// Apply the specified public key to the socket.
     bool set_public_key(const config::sodium& key);
 
-    /// This must be called on the socket thread.
     /// Apply the specified private key to the socket.
     bool set_private_key(const config::sodium& key);
 
-    /// This must be called on the socket thread.
     /// Apply the keys of the specified certificate to the socket.
     bool set_certificate(const certificate& certificate);
 
@@ -130,9 +121,8 @@ private:
     bool set(int32_t option, int32_t value);
     bool set(int32_t option, const std::string& value);
 
-    // This is protected by mutex.
+    // This value is unprotected.
     void* self_;
-    mutable shared_mutex mutex_;
 
     const identifier identifier_;
     const int32_t send_buffer_;

--- a/src/zmq/socket.cpp
+++ b/src/zmq/socket.cpp
@@ -88,51 +88,27 @@ socket::~socket()
     stop();
 }
 
-// This must be called on the socket thread.
 bool socket::stop()
 {
-    ///////////////////////////////////////////////////////////////////////////
-    // Critical Section
-    unique_lock lock(mutex_);
-
-    if (self_ == nullptr)
-        return true;
-
-    const auto result = zmq_close(self_) != zmq_fail;
-
-    self_ = nullptr;
-    return result;
-    ///////////////////////////////////////////////////////////////////////////
+    return self_ == nullptr || zmq_close(self_) != zmq_fail;
 }
 
 socket::operator const bool() const
 {
-    ///////////////////////////////////////////////////////////////////////////
-    // Critical Section
-    shared_lock lock(mutex_);
-
     return self_ != nullptr;
-    ///////////////////////////////////////////////////////////////////////////
 }
 
 void* socket::self()
 {
-    ///////////////////////////////////////////////////////////////////////////
-    // Critical Section
-    shared_lock lock(mutex_);
-
-    // This may become invalid after return. The guard only ensures atomicity.
     return self_;
-    ///////////////////////////////////////////////////////////////////////////
 }
 
-// To preserve idetity the id survives after the socket is destroyed.
+// To preserve identity the id survives after the socket is destroyed.
 identifier socket::id() const
 {
     return identifier_;
 }
 
-// This must be called on the socket thread.
 code socket::bind(const config::endpoint& address)
 {
     if (zmq_bind(self_, address.to_string().c_str()) == zmq_fail)
@@ -141,7 +117,6 @@ code socket::bind(const config::endpoint& address)
     return error::success;
 }
 
-// This must be called on the socket thread.
 code socket::connect(const config::endpoint& address)
 {
     if (zmq_connect(self_, address.to_string().c_str()) == zmq_fail)
@@ -166,7 +141,6 @@ bool socket::set(int32_t option, const std::string& value)
     return zmq_setsockopt(self_, option, buffer, value.size()) != zmq_fail;
 }
 
-// This must be called on the socket thread.
 // For NULL security, ZAP calls are only made for non-empty domain.
 // For PLAIN/CURVE, calls are always made if ZAP handler is present.
 bool socket::set_authentication_domain(const std::string& domain)
@@ -174,35 +148,30 @@ bool socket::set_authentication_domain(const std::string& domain)
     return set(ZMQ_ZAP_DOMAIN, domain);
 }
 
-// This must be called on the socket thread.
 // Defines whether the socket will act as server for CURVE security.
 bool socket::set_curve_server()
 {
     return set(ZMQ_CURVE_SERVER, zmq_true);
 }
 
-// This must be called on the socket thread.
 // Sets socket's long term server key, must set this on CURVE client sockets.
 bool socket::set_curve_client(const config::sodium& server_public_key)
 {
     return set(ZMQ_CURVE_SERVERKEY, server_public_key.to_string());
 }
 
-// This must be called on the socket thread.
 // Sets socket's long term public key, must set this on CURVE client sockets.
 bool socket::set_public_key(const config::sodium& key)
 {
     return set(ZMQ_CURVE_PUBLICKEY, key.to_string());
 }
 
-// This must be called on the socket thread.
 // You must set this on both CURVE client and server sockets.
 bool socket::set_private_key(const config::sodium& key)
 {
     return set(ZMQ_CURVE_SECRETKEY, key.to_string());
 }
 
-// This must be called on the socket thread.
 // Use on client for both set_public_key and set_private_key from a cert.
 // If CURVE is not required by server, call set_certificate({ null_hash })
 // to generate an arbitrary client certificate for a secure socket.
@@ -213,7 +182,6 @@ bool socket::set_certificate(const certificate& certificate)
         set_private_key(certificate.private_key().to_string());
 }
 
-// This must be called on the socket thread.
 bool socket::set_socks_proxy(const config::authority& socks_proxy)
 {
     return !socks_proxy || set(ZMQ_SOCKS_PROXY, socks_proxy.to_string());

--- a/test/zmq/authenticator.cpp
+++ b/test/zmq/authenticator.cpp
@@ -54,7 +54,6 @@ BOOST_AUTO_TEST_CASE(authenticator__started__before_socket__valid_context)
     BOOST_REQUIRE(authenticator.start());
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
-    pusher.stop();
 }
 
 // apply
@@ -67,7 +66,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__public_without_server_private_key__tr
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(authenticator.apply(pusher, TEST_DOMAIN, false));
-    pusher.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__apply__public_empty_domain_no_addresses__true)
@@ -78,7 +76,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__public_empty_domain_no_addresses__tru
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(authenticator.apply(pusher, "", false));
-    pusher.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__apply__public_empty_domain_with_allow__false)
@@ -90,7 +87,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__public_empty_domain_with_allow__false
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(!authenticator.apply(pusher, "", false));
-    pusher.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__apply__public_empty_domain_with_deny__false)
@@ -102,7 +98,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__public_empty_domain_with_deny__false)
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(!authenticator.apply(pusher, "", false));
-    pusher.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__apply__secure_without_server_private_key__false)
@@ -113,7 +108,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__secure_without_server_private_key__fa
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(!authenticator.apply(pusher, TEST_DOMAIN, true));
-    pusher.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__apply__secure_with_server_private_key__true)
@@ -128,7 +122,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__secure_with_server_private_key__true)
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(authenticator.apply(pusher, TEST_DOMAIN, true));
-    pusher.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__apply__secure_with_empty_domain__true)
@@ -143,7 +136,6 @@ BOOST_AUTO_TEST_CASE(authenticator__apply__secure_with_empty_domain__true)
     zmq::socket pusher(authenticator, role::pusher);
     BOOST_REQUIRE(pusher);
     BOOST_REQUIRE(authenticator.apply(pusher, "", true));
-    pusher.stop();
 }
 
 // push/pull clent-server tests
@@ -171,8 +163,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands__unauthenticated__rece
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_secure_certified__blocked)
@@ -196,8 +186,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_secure_certified__bloc
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_secure__blocked)
@@ -221,8 +209,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_secure__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_certified__blocked)
@@ -243,8 +229,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_certified__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_unsecure_uncertified__received)
@@ -265,8 +249,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__grasslands_unsecure_uncertified__
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 // strawhouse (public and anonymous with IP restrictions)
@@ -288,8 +270,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_bad_allow__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_bad_and_good_allow__received)
@@ -310,8 +290,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_bad_and_good_allow__re
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_client_good_allow__received)
@@ -331,8 +309,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_client_good_allow__rec
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_client_bad_deny__received)
@@ -352,8 +328,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_client_bad_deny__recei
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_bad_and_good_deny__blocked)
@@ -374,8 +348,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_bad_and_good_deny__blo
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_client_good_deny__blocked)
@@ -395,8 +367,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_client_good_deny__bloc
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_good_deny_before_same_allow__blocked)
@@ -417,8 +387,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_good_deny_before_same_
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_good_deny_after_same_allow__received)
@@ -439,8 +407,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__strawhouse_good_deny_after_same_a
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 // brickhouse = stonehouse - strawhouse (private and anonymous)
@@ -468,8 +434,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_unsecure__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_uncertified__blocked)
@@ -494,8 +458,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_uncertified__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_unsecure_uncertified__blocked)
@@ -518,8 +480,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_unsecure_uncertified__
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_secure_certified__received)
@@ -544,8 +504,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__brickhouse_secure_certified__rece
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 // ironhouse (private with mututal authentication)
@@ -576,8 +534,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unapplied__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unsecure__blocked)
@@ -606,8 +562,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unsecure__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_uncertified__blocked)
@@ -636,8 +590,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_uncertified__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unsecure_uncertified__blocked)
@@ -666,8 +618,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unsecure_uncertified__b
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unauthorized__blocked)
@@ -696,8 +646,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_unauthorized__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_authorized__received)
@@ -726,8 +674,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_authorized__received)
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_bad_allow__blocked)
@@ -757,8 +703,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__ironhouse_bad_allow__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 // safehouse = ironhouse + strawhouse (private with mututal authentication and IP restrictions)
@@ -790,8 +734,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_bad_deny__received)
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_bad_and_good_deny__blocked)
@@ -822,8 +764,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_bad_and_good_deny__bloc
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_allow__received)
@@ -853,8 +793,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_allow__received)
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_and_bad_allow__received)
@@ -885,8 +823,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_and_bad_allow__rec
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_deny__blocked)
@@ -916,8 +852,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_deny__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_deny_before_same_allow__blocked)
@@ -948,8 +882,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_deny_before_same_a
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_deny_after_same_allow__received)
@@ -980,8 +912,6 @@ BOOST_AUTO_TEST_CASE(authenticator__push_pull__safehouse_good_deny_after_same_al
 
     SEND_MESSAGE(pusher);
     RECEIVE_MESSAGE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/zmq/socket.cpp
+++ b/test/zmq/socket.cpp
@@ -51,11 +51,9 @@ BOOST_AUTO_TEST_CASE(socket__push_pull__brickhouse__blocked)
 
     SEND_MESSAGE(pusher);
     RECEIVE_FAILURE(puller);
-    pusher.stop();
-    puller.stop();
 }
 
-// PUSH and PULL are asymmetrical, synchronous and not enveloped.
+// PUSH and PULL [asymmetrical, synchronous, unroutable]
 BOOST_AUTO_TEST_CASE(socket__push_pull__grasslands__received)
 {
     zmq::context context;
@@ -71,11 +69,9 @@ BOOST_AUTO_TEST_CASE(socket__push_pull__grasslands__received)
 
     SEND_MESSAGE(server);
     RECEIVE_MESSAGE(client);
-    server.stop();
-    client.stop();
 }
 
-// PAIR is symmetrical, synchronous and not enveloped.
+// PAIR and PAIR [symmetrical, synchronous, unroutable]
 BOOST_AUTO_TEST_CASE(socket__pair_pair__grasslands__received)
 {
     zmq::context context;
@@ -91,11 +87,9 @@ BOOST_AUTO_TEST_CASE(socket__pair_pair__grasslands__received)
 
     SEND_MESSAGE(server);
     RECEIVE_MESSAGE(client);
-    server.stop();
-    client.stop();
 }
 
-// REQ and REP are asymetrical, synchronous and enveloped.
+// REQ and REP [asymetrical, synchronous, routable]
 // zguide.zeromq.org/page:all#The-Simple-Reply-Envelope
 BOOST_AUTO_TEST_CASE(socket__requester_replier__grasslands__received)
 {
@@ -112,11 +106,9 @@ BOOST_AUTO_TEST_CASE(socket__requester_replier__grasslands__received)
 
     SEND_MESSAGE(client);
     RECEIVE_MESSAGE(server);
-    client.stop();
-    server.stop();
 }
 
-////// PUB and SUB are asymmtrical, asynchronous and not enveloped.
+////// PUB and SUB [asymmtrical, asynchronous, routable (subscription)]
 ////BOOST_AUTO_TEST_CASE(socket__publisher_subscriber__grasslands__received)
 ////{
 ////    zmq::context context;
@@ -137,8 +129,6 @@ BOOST_AUTO_TEST_CASE(socket__requester_replier__grasslands__received)
 ////    // If a “publish” service has been started already and then when you start
 ////    // “subscribe” service, it would not receive message already published. 
 ////    RECEIVE_MESSAGE(client);
-////    server.stop();
-////    client.stop();
 ////}
 
 // XPUB and XSUB are for routing PUB-SUB subscriptions


### PR DESCRIPTION
The tests do not require socket.stop() calls because the context must always be created before the sockets and we can therefore rely on LIFO cleanup giving the proper ordering of destructs.