### PR TITLE
zmq socket subscription filter methods added.

### DIFF
--- a/include/bitcoin/protocol/zmq/socket.hpp
+++ b/include/bitcoin/protocol/zmq/socket.hpp
@@ -115,11 +115,11 @@ public:
     /// Configure the socket to connect through the specified socks5 proxy.
     bool set_socks_proxy(const config::authority& socks_proxy);
 
-    /////// Configure subscriber socket to apply the message filter.
-    ////bool set_subscription(const data_chunk& filter);
+    /// Configure subscriber socket to apply the message filter.
+    bool set_subscription(const data_chunk& filter);
 
-    /////// Configure subscriber socket to remove the message filter.
-    ////bool set_unsubscription(const data_chunk& filter);
+    /// Configure subscriber socket to remove the message filter.
+    bool set_unsubscription(const data_chunk& filter);
 
     /// Send a message on this socket.
     code send(message& packet);
@@ -133,6 +133,7 @@ protected:
     bool set32(int32_t option, int32_t value);
     bool set64(int32_t option, int64_t value);
     bool set(int32_t option, const std::string& value);
+    bool set(int32_t option, const data_chunk& value);
 
 private:
     void* self_;

--- a/src/zmq/socket.cpp
+++ b/src/zmq/socket.cpp
@@ -33,7 +33,7 @@
 namespace libbitcoin {
 namespace protocol {
 namespace zmq {
-    
+
 static const auto subscribe_all = "";
 static constexpr int32_t zmq_true = 1;
 static constexpr int32_t zmq_false = 0;
@@ -42,7 +42,7 @@ static constexpr int32_t reconnect_interval = 100;
 static const bc::protocol::settings default_settings;
 
 // Linger
-// The default value of -1 specifies an infinite linger period. Pending 
+// The default value of -1 specifies an infinite linger period. Pending
 // messages shall not be discarded after a call to zmq_close(); attempting to
 // terminate the socket's context with zmq_term() shall block until all pending
 // messages have been sent to a peer. The value 0 specifies no linger period.
@@ -241,6 +241,13 @@ bool socket::set(int32_t option, const std::string& value)
     return zmq_setsockopt(self_, option, buffer, value.size()) != zmq_fail;
 }
 
+// private
+bool socket::set(int32_t option, const data_chunk& value)
+{
+    return zmq_setsockopt(self_, option, value.data(), value.size())
+        != zmq_fail;
+}
+
 // For NULL security, ZAP calls are only made for non-empty domain.
 // For PLAIN/CURVE, calls are always made if ZAP handler is present.
 bool socket::set_authentication_domain(const std::string& domain)
@@ -286,6 +293,16 @@ bool socket::set_certificate(const certificate& certificate)
 bool socket::set_socks_proxy(const config::authority& socks_proxy)
 {
     return socks_proxy && set(ZMQ_SOCKS_PROXY, socks_proxy.to_string());
+}
+
+bool socket::set_subscription(const data_chunk& filter)
+{
+    return set(ZMQ_SUBSCRIBE, filter);
+}
+
+bool socket::set_unsubscription(const data_chunk& filter)
+{
+    return set(ZMQ_UNSUBSCRIBE, filter);
 }
 
 code socket::send(message& packet)

--- a/test/utility.hpp
+++ b/test/utility.hpp
@@ -26,6 +26,7 @@
 
 #define TEST_DOMAIN "testing"
 #define TEST_MESSAGE "hello world!"
+#define TEST_TOPIC "hello"
 #define TEST_HOST "127.0.0.1"
 #define TEST_HOST_BAD "127.0.0.42"
 #define TEST_PUBLIC_ENDPOINT "tcp://" TEST_HOST ":9000"


### PR DESCRIPTION
@evoskuil, I noticed the zmq socket filter methods set_subscription/set_unsubscription were commented in, but not implemented, is there a specific reason these were left unimplemented? I have added them together with two unit tests. I realise the current subscriber socket is currently implemented with subscribe_all per default, but it may be useful to apply filters no the client side, especially with a custom zmq routing setup. Please let me know what you think!