### PR TITLE
Allow configured hostname for HTTP socket services

### DIFF
--- a/src/web/manager.cpp
+++ b/src/web/manager.cpp
@@ -104,9 +104,8 @@ bool manager::bind(const config::endpoint& address, const bind_options& options)
 {
     if (address.host() != "*")
     {
-        LOG_INFO(LOG_PROTOCOL_HTTP)
-            << "Failed to bind to named host (unsupported): " << address;
-        return false;
+        LOG_WARNING(LOG_PROTOCOL_HTTP)
+            << "Detected named host, but binding to '*': " << address;
     }
 
     port_ = address.port();


### PR DESCRIPTION
Allow configured hostname for HTTP socket services, primarily for public facing servers.  Instead of failing to bind, warn that all interfaces will be bound on the configured port.
