### PR TITLE
resolve noop comparison warning

### DIFF
--- a/src/zmq/certificate.cpp
+++ b/src/zmq/certificate.cpp
@@ -79,7 +79,7 @@ bool certificate::create(config::sodium& out_public,
 {
     // Loop until neither key's base85 encoding includes the # character.
     // This ensures that the value can be used in libbitcoin settings files.
-    for (uint8_t attempt = 0; attempt <= max_uint8; attempt++)
+    while (true)
     {
         char public_key[zmq_encoded_key_size + 1] = { 0 };
         char private_key[zmq_encoded_key_size + 1] = { 0 };
@@ -95,8 +95,6 @@ bool certificate::create(config::sodium& out_public,
             return out_public;
         }
     }
-
-    return false;
 }
 
 certificate::operator bool() const

--- a/src/zmq/certificate.cpp
+++ b/src/zmq/certificate.cpp
@@ -79,7 +79,7 @@ bool certificate::create(config::sodium& out_public,
 {
     // Loop until neither key's base85 encoding includes the # character.
     // This ensures that the value can be used in libbitcoin settings files.
-    while (true)
+    for (uint8_t attempt = 0; attempt < max_uint8; attempt++)
     {
         char public_key[zmq_encoded_key_size + 1] = { 0 };
         char private_key[zmq_encoded_key_size + 1] = { 0 };
@@ -95,6 +95,8 @@ bool certificate::create(config::sodium& out_public,
             return out_public;
         }
     }
+
+    return false;
 }
 
 certificate::operator bool() const


### PR DESCRIPTION
```
libbitcoin-protocol/src/zmq/certificate.cpp:82:42: warning: comparison is always true due to limited range of data type [-Wtype-limits]
     for (uint8_t attempt = 0; attempt <= max_uint8; attempt++)
```
`attempt` will wrap and the loop never terminates.  It looks like that's fine rare behavior.